### PR TITLE
Feature/01 lift state up for accordion

### DIFF
--- a/src/App-v1.js
+++ b/src/App-v1.js
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import './index.css';
+
+const faqs = [
+  {
+    title: 'Where are these chairs assembled?',
+    text: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Accusantium, quaerat temporibus quas dolore provident nisi ut aliquid ratione beatae sequi aspernatur veniam repellendus.',
+  },
+  {
+    title: 'How long do I have to return my chair?',
+    text: 'Pariatur recusandae dignissimos fuga voluptas unde optio nesciunt commodi beatae, explicabo natus.',
+  },
+  {
+    title: 'Do you ship to countries outside the EU?',
+    text: 'Excepturi velit laborum, perspiciatis nemo perferendis reiciendis aliquam possimus dolor sed! Dolore laborum ducimus veritatis facere molestias!',
+  },
+];
+
+export default function App() {
+  return (
+    <div>
+      <Accordion data={faqs} />
+    </div>
+  );
+}
+
+function Accordion({ data }) {
+  return (
+    <div className="accordion">
+      {data.map((el, i) => (
+        <AccordionItem title={el.title} text={el.text} num={i} key={el.title} />
+      ))}
+    </div>
+  );
+}
+
+function AccordionItem({ num, title, text }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function handleToggle() {
+    setIsOpen((isOpen) => !isOpen);
+  }
+
+  return (
+    <div className={`item ${isOpen ? 'open' : ''}`} onClick={handleToggle}>
+      <p className="number">{num < 9 ? `0${num + 1}` : num + 1}</p>
+      <p className="title">{title}</p>
+      <p className="icon">{isOpen ? '-' : '+'}</p>
+      {isOpen && <div className="content-box">{text}</div>}
+    </div>
+  );
+}

--- a/src/App.js
+++ b/src/App.js
@@ -25,20 +25,45 @@ export default function App() {
 }
 
 function Accordion({ data }) {
+  const [curOpen, setCurOpen] = useState(null);
+
   return (
     <div className="accordion">
       {data.map((el, i) => (
-        <AccordionItem title={el.title} text={el.text} num={i} key={el.title} />
+        <AccordionItem
+          curOpen={curOpen}
+          onOpen={setCurOpen}
+          title={el.title}
+          num={i}
+          key={el.title}
+        >
+          {el.text}
+        </AccordionItem>
       ))}
+
+      <AccordionItem
+        curOpen={curOpen}
+        onOpen={setCurOpen}
+        title="Test 1"
+        num={20}
+        key="test 1"
+      >
+        <p>Allows React developers to:</p>
+        <ul>
+          <li>Break up UI into components </li>
+          <li>Make components reusuable </li>
+          <li>Place state efficiently</li>
+        </ul>
+      </AccordionItem>
     </div>
   );
 }
 
-function AccordionItem({ num, title, text }) {
-  const [isOpen, setIsOpen] = useState(false);
+function AccordionItem({ num, title, children, curOpen, onOpen }) {
+  const isOpen = num === curOpen;
 
   function handleToggle() {
-    setIsOpen((isOpen) => !isOpen);
+    onOpen(isOpen ? null : num);
   }
 
   return (
@@ -46,7 +71,7 @@ function AccordionItem({ num, title, text }) {
       <p className="number">{num < 9 ? `0${num + 1}` : num + 1}</p>
       <p className="title">{title}</p>
       <p className="icon">{isOpen ? '-' : '+'}</p>
-      {isOpen && <div className="content-box">{text}</div>}
+      {isOpen && <div className="content-box">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
**Lift State Up for Accordion Component**

## Summary

This PR lifts the `curOpen` state from the `AccordionItem` component to the parent `Accordion` component. By doing so, we ensure that the open/close state is shared across all accordion items, allowing only one item to be open at a time.

## Why this change?

- **Single source of truth:** The `curOpen` state now resides in the parent `Accordion` component, holding the index of the currently open item.
- **Synchronized behavior:** Each `AccordionItem` can now "communicate" with others — when one item opens, the others close.
- **Consistent state management:** Previously, individual states within items would cause them to open independently. Lifting the state ensures only one item can be open at any moment.

## How it works

- `curOpen` is stored in the `Accordion` component.
- Each `AccordionItem` receives `curOpen` and an `onOpen` function as props.
- When an item is clicked, it calls `onOpen(num)`, updating the parent’s state via `setCurOpen(num)`.
- This triggers a re-render, keeping the accordion items in sync.

## Changes

- Added `curOpen` state and `setCurOpen` function to `Accordion`.
- Passed `curOpen` and `onOpen` as props to `AccordionItem`.
- Adjusted the `handleToggle` function in `AccordionItem` to call `onOpen(num)`.

---

### Learning Source:
- **Course**: [The Ultimate React Course by Jonas Schmedtmann](https://www.udemy.com/course/the-ultimate-react-course/)
